### PR TITLE
Loaded chat conversations from doctor_patients

### DIFF
--- a/app/src/main/java/com/unibuc/medtrack/data/repositories/doctor_patient/DoctorPatientRepository.kt
+++ b/app/src/main/java/com/unibuc/medtrack/data/repositories/doctor_patient/DoctorPatientRepository.kt
@@ -3,4 +3,5 @@ package com.unibuc.medtrack.data.repositories.doctor_patient
 interface DoctorPatientRepository{
     suspend fun addDoctorPatient(doctorId: String, patientId: String)
     suspend fun getPatientIdsForDoctor(doctorId: String): List<String>
+    suspend fun getDoctorIdsForPatient(patientId: String): List<String>
 }

--- a/app/src/main/java/com/unibuc/medtrack/data/repositories/doctor_patient/DoctorPatientRepositoryLocal.kt
+++ b/app/src/main/java/com/unibuc/medtrack/data/repositories/doctor_patient/DoctorPatientRepositoryLocal.kt
@@ -9,4 +9,6 @@ class DoctorPatientRepositoryLocal(private val dao: DoctorPatientDao) : DoctorPa
     }
     override suspend fun getPatientIdsForDoctor(doctorId: String): List<String> =
         dao.getPatientIdsForDoctor(doctorId)
+    override suspend fun getDoctorIdsForPatient(patientId: String): List<String> =
+        dao.getDoctorIdsForPatient(patientId)
 }

--- a/app/src/main/java/com/unibuc/medtrack/ui/home/PatientChatsViewModel.kt
+++ b/app/src/main/java/com/unibuc/medtrack/ui/home/PatientChatsViewModel.kt
@@ -11,6 +11,7 @@ import com.unibuc.medtrack.data.models.DoctorUserDTO
 import com.unibuc.medtrack.data.models.PatientUserDTO
 import com.unibuc.medtrack.data.models.UserType
 import com.unibuc.medtrack.data.repositories.chat_messages.ChatMessagesRepository
+import com.unibuc.medtrack.data.repositories.doctor_patient.DoctorPatientRepository
 import com.unibuc.medtrack.data.repositories.doctors.DoctorsRepository
 import com.unibuc.medtrack.data.repositories.patients.PatientsRepository
 import com.unibuc.medtrack.data.repositories.users.UsersRepository
@@ -24,6 +25,7 @@ import javax.inject.Inject
 class PatientChatsViewModel @Inject constructor(
     private val usersRepository: UsersRepository,
     private val chatMessagesRepository: ChatMessagesRepository,
+    private val doctorPatientRepository: DoctorPatientRepository,
     private val doctorsRepository: DoctorsRepository,
     private val patientsRepository: PatientsRepository,
     private val sessionManager: SessionManager
@@ -53,7 +55,7 @@ class PatientChatsViewModel @Inject constructor(
 
                 if (_myRole.value == UserType.PATIENT) {
                     val doctorIds = withContext(Dispatchers.IO) {
-                        chatMessagesRepository.getAllMyConversationUserIds(myId)
+                        doctorPatientRepository.getDoctorIdsForPatient(myId)
                     }!!
 
                     _doctorDtos.value = withContext(Dispatchers.IO) {
@@ -64,7 +66,7 @@ class PatientChatsViewModel @Inject constructor(
                 }
                 else if (_myRole.value == UserType.DOCTOR) {
                     val patientIds = withContext(Dispatchers.IO) {
-                        chatMessagesRepository.getAllMyConversationUserIds(myId)
+                        doctorPatientRepository.getPatientIdsForDoctor(myId)
                     }!!
 
                     _patientDtos.value = withContext(Dispatchers.IO) {

--- a/server.py
+++ b/server.py
@@ -5,29 +5,29 @@ app = Flask(__name__)
 
 #   SERVER UNDE SE DUC REQ. HTTP
 messages = [
-    {'id': '1000',
-     'senderId': 'DOCTOR-ID',
-     'receiverId': 'PATIENT-ID',
-     'message': 'Nu uitati sa va luati tratamentul la ora 18!',
-     'timeSent': '2025-05-24'},
-
-    {'id': '1001',
-     'senderId': 'PATIENT-ID',
-     'receiverId': 'DOCTOR-ID',
-     'message': 'Multumesc ca mi-ati amintit!',
-     'timeSent': '2025-05-24'},
-
-    {'id': '1002',
-     'senderId': 'PATIENT-ID',
-     'receiverId': 'DOCTOR-ID',
-     'message': 'O zi buna!',
-     'timeSent': '2025-05-24'},
-
-    {'id': '1003',
-     'senderId': 'DOCTOR-ID',
-     'receiverId': 'PATIENT-ID',
-     'message': 'Nu aveti pentru ce! O zi buna de asemenea!',
-     'timeSent': '2025-05-24'}
+    # {'id': '1000',
+    #  'senderId': 'DOCTOR-ID',
+    #  'receiverId': 'PATIENT-ID',
+    #  'message': 'Nu uitati sa va luati tratamentul la ora 18!',
+    #  'timeSent': '2025-05-24'},
+    #
+    # {'id': '1001',
+    #  'senderId': 'PATIENT-ID',
+    #  'receiverId': 'DOCTOR-ID',
+    #  'message': 'Multumesc ca mi-ati amintit!',
+    #  'timeSent': '2025-05-24'},
+    #
+    # {'id': '1002',
+    #  'senderId': 'PATIENT-ID',
+    #  'receiverId': 'DOCTOR-ID',
+    #  'message': 'O zi buna!',
+    #  'timeSent': '2025-05-24'},
+    #
+    # {'id': '1003',
+    #  'senderId': 'DOCTOR-ID',
+    #  'receiverId': 'PATIENT-ID',
+    #  'message': 'Nu aveti pentru ce! O zi buna de asemenea!',
+    #  'timeSent': '2025-05-24'}
 ]
 
 


### PR DESCRIPTION
- Chat conversations are now populated from the doctor_patients table, instead of chat_messages (this means that, for instance, patients will still show up in the doctor's chat conversations fragment, even if their chat hasn't had a single message sent yet);
- Commented out the preloaded messages from the python server.